### PR TITLE
Use buster-backports and replace `apt` with `apt-get`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian:buster
 
 # Add debian unstable repo for wireguard packages
-RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable-wireguard.list && \
- printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
+RUN echo "deb http://deb.debian.org/debian/ buster-backports main" > /etc/apt/sources.list.d/buster-backports.list
 
 # Install wireguard packges
 RUN apt update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM debian:buster
 RUN echo "deb http://deb.debian.org/debian/ buster-backports main" > /etc/apt/sources.list.d/buster-backports.list
 
 # Install wireguard packges
-RUN apt update && \
- apt install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv && \
- apt clean
+RUN apt-get update && \
+ apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv && \
+ apt-get clean
 
 # Add main work dir to PATH
 WORKDIR /scripts

--- a/install-module
+++ b/install-module
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-apt update
+apt-get update
 
 # get kernel version
 KVER=`uname -r`
 
 # install headers
-apt install -y linux-headers-$KVER
+apt-get install -y linux-headers-$KVER
 
 # install and build with wireguard-dkms
-apt install -y --no-install-recommends wireguard-dkms
+apt-get install -y --no-install-recommends wireguard-dkms


### PR DESCRIPTION
Wireguard is now available on `buster-backports`, it's better to use it than pulling from `unstable`.
Also, `apt` complains that its CLI interface is not stable, so it is better to avoid using it in scripts.

**I have tested only the `run` script, not the others**