### PR TITLE
Add example to use as client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,28 @@ PersistentKeepalive = 25
 ## Other Notes
 - This Docker image also has a iptables NAT (MASQUERADE) rule already configured to make traffic through the VPN out to the Internet work. This can be disabled by setting the environment variable `IPTABLES_MASQ=0`.
 - For some clients (a GL.inet router in my case) you may have trouble with HTTPS (SSL/TLS) due to the MTU on the VPN. Ping and HTTP work fine but HTTPS does not for some sites. This can be fixed with [MSS Clamping](https://www.tldp.org/HOWTO/Adv-Routing-HOWTO/lartc.cookbook.mtu-mss.html). This is simply a checkbox in the OpenWRT Firewall settings interface.
-- This image can be used as a "client" as well. If you want to forward all traffic through the VPN (`AllowedIPs = 0.0.0.0/0`), you need to use the `--privileged` flag when running the container
+
+## Use as client
+- This image can be used as a "client" as well. If you want to forward all traffic through the VPN (`AllowedIPs = 0.0.0.0/0`), you need to use the `--privileged` flag when running the container, or you got error `Read-only file system`.
+- If you got error `RTNETLINK answers: Permission denied`, you need to use the `--sysctl net.ipv6.conf.all.disable_ipv6=0` flag.
+
+### Client example
+```
+docker run -d \
+--privileged \
+--restart=always \
+--name wireguard-client \
+--cap-add NET_ADMIN \
+--cap-add SYS_MODULE \
+--sysctl net.ipv6.conf.all.disable_ipv6=0 \
+-v <client config dir>wg0.conf:/etc/wireguard/wg0.conf \
+cmulk/wireguard-docker:alpine
+```
+
+### Example connect to client from another container
+```
+docker run -it --rm --net=container:wireguard-client alpine wget -q -O - ipinfo.io/ip
+```
 
 ## docker-compose
 Sample docker-compose.yml


### PR DESCRIPTION
- Add notes for fix errors `Read-only file system` and `RTNETLINK answers: Permission denied` when use as client. 
- Add client examples.