### PR TITLE
Watch for configuration changes

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # Install wireguard packges
-RUN apk --no-cache add wireguard-tools iptables ip6tables
+RUN apk --no-cache add wireguard-tools iptables ip6tables inotify-tools
 
 # Add main work dir to PATH
 WORKDIR /scripts

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,6 +10,9 @@ ENV PATH="/scripts:${PATH}"
 # Use iptables masquerade NAT rule
 ENV IPTABLES_MASQ=1
 
+# Watch for changes to interface conf files (default off)
+ENV WATCH_CHANGES=0
+
 # Copy scripts to containers
 COPY run /scripts
 COPY genkeys /scripts

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -15,6 +15,9 @@ ENV PATH="/scripts:${PATH}"
 # Use iptables masquerade NAT rule
 ENV IPTABLES_MASQ=1
 
+# Watch for changes to interface conf files (default off)
+ENV WATCH_CHANGES=0
+
 # Copy scripts to containers
 COPY install-module /scripts
 COPY run /scripts

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -5,7 +5,7 @@ RUN echo "deb http://deb.debian.org/debian/ buster-backports main" > /etc/apt/so
 
 # Install wireguard packges
 RUN apt-get update && \
- apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv && \
+ apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv inotify-tools && \
  apt-get clean
 
 # Add main work dir to PATH

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -6,7 +6,7 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.li
 
 # Install wireguard packges
 RUN apt-get update && \
- apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv && \
+ apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv inotify-tools && \
  apt-get clean
 
 # Add main work dir to PATH

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -16,6 +16,9 @@ ENV PATH="/scripts:${PATH}"
 # Use iptables masquerade NAT rule
 ENV IPTABLES_MASQ=1
 
+# Watch for changes to interface conf files (default off)
+ENV WATCH_CHANGES=0
+
 # Copy scripts to containers
 COPY install-module /scripts
 COPY run /scripts

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ PersistentKeepalive = 25
 ## Other Notes
 - This Docker image also has a iptables NAT (MASQUERADE) rule already configured to make traffic through the VPN out to the Internet work. This can be disabled by setting the environment variable `IPTABLES_MASQ=0`.
 - For some clients (a GL.inet router in my case) you may have trouble with HTTPS (SSL/TLS) due to the MTU on the VPN. Ping and HTTP work fine but HTTPS does not for some sites. This can be fixed with [MSS Clamping](https://www.tldp.org/HOWTO/Adv-Routing-HOWTO/lartc.cookbook.mtu-mss.html). This is simply a checkbox in the OpenWRT Firewall settings interface.
+- It's possible to watch for changes to any of the configuration files in `/etc/wireguard` (in the container) and automatically restart wireguard as soon as one changes. This is very useful when combining this docker image with a wireguard GUI. To enable watching for changes, set the environment variable `WATCH_CHANGES` to any value.
 
 ## Use as client
 - This image can be used as a "client" as well. If you want to forward all traffic through the VPN (`AllowedIPs = 0.0.0.0/0`), you need to use the `--privileged` flag when running the container, or you got error `Read-only file system`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ PersistentKeepalive = 25
 ## Other Notes
 - This Docker image also has a iptables NAT (MASQUERADE) rule already configured to make traffic through the VPN out to the Internet work. This can be disabled by setting the environment variable `IPTABLES_MASQ=0`.
 - For some clients (a GL.inet router in my case) you may have trouble with HTTPS (SSL/TLS) due to the MTU on the VPN. Ping and HTTP work fine but HTTPS does not for some sites. This can be fixed with [MSS Clamping](https://www.tldp.org/HOWTO/Adv-Routing-HOWTO/lartc.cookbook.mtu-mss.html). This is simply a checkbox in the OpenWRT Firewall settings interface.
-- It's possible to watch for changes to any of the configuration files in `/etc/wireguard` (in the container) and automatically restart wireguard as soon as one changes. This is very useful when combining this docker image with a wireguard GUI. To enable watching for changes, set the environment variable `WATCH_CHANGES` to any value.
+- It's possible to watch for changes to any of the configuration files in `/etc/wireguard` (in the container) and automatically restart wireguard as soon as one changes. This is very useful when combining this docker image with a wireguard GUI. To enable watching for changes, set the environment variable `WATCH_CHANGES=1`.
 
 ## Use as client
 - This image can be used as a "client" as well. If you want to forward all traffic through the VPN (`AllowedIPs = 0.0.0.0/0`), you need to use the `--privileged` flag when running the container, or you got error `Read-only file system`.

--- a/run
+++ b/run
@@ -44,7 +44,7 @@ finish () {
 
 trap finish TERM INT QUIT
 
-if [ -z "$WATCH_CHANGES" ]; then
+if [ $WATCH_CHANGES -eq 0 ]; then
     sleep infinity &
     wait $!
 else

--- a/run
+++ b/run
@@ -44,7 +44,12 @@ finish () {
 
 trap finish TERM INT QUIT
 
-while inotifywait -e modify -e create /etc/wireguard; do
-    stop_interfaces
-    start_interfaces
-done
+if [ -z "$WATCH_CHANGES" ]; then
+    sleep infinity &
+    wait $!
+else
+    while inotifywait -e modify -e create /etc/wireguard; do
+        stop_interfaces
+        start_interfaces
+    done
+fi

--- a/run
+++ b/run
@@ -9,10 +9,20 @@ if [ -z $interfaces ]; then
     exit 1
 fi
 
-for interface in $interfaces; do
-    echo "$(date): Starting Wireguard $interface"
-    wg-quick up $interface
-done
+start_interfaces() {
+    for interface in $interfaces; do
+        echo "$(date): Starting Wireguard $interface"
+        wg-quick up $interface
+    done
+}
+
+stop_interfaces() {
+    for interface in $interfaces; do
+        wg-quick down $interface
+    done
+}
+
+start_interfaces
 
 # Add masquerade rule for NAT'ing VPN traffic bound for the Internet
 
@@ -24,9 +34,7 @@ fi
 # Handle shutdown behavior
 finish () {
     echo "$(date): Shutting down Wireguard"
-    for interface in $interfaces; do
-        wg-quick down $interface
-    done
+    stop_interfaces
     if [ $IPTABLES_MASQ -eq 1 ]; then
         iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
     fi
@@ -36,5 +44,7 @@ finish () {
 
 trap finish TERM INT QUIT
 
-sleep infinity &
-wait $!
+while inotifywait -e modify -e create /etc/wireguard; do
+    stop_interfaces
+    start_interfaces
+done


### PR DESCRIPTION
This PR enables watching and waiting for an interface configuration change so that wireguard is automatically restarted every time its configuration changes. My use-case for this is that I want to use a GUI to manage my wireguard clients. However, the GUI I want to use (https://github.com/vx3r/wg-gen-web) does not make any attempt at restarting wireguard when it modifies a configuration file, which I think makes sense. However, I still didn't want to manually restart wireguard every time I made a change in the GUI, because that somewhat defeats the purpose of having a GUI in the first place.

The `wg-gen-web` project suggests a few solutions, the simplest of which is what I've implemented here (https://github.com/vx3r/wg-gen-web#using-inotifywait for details).

I've tested the debian buster image and it works very well. Perhaps additional testing would be required for the other two image variants, but I'm fairly confident that it would also work as expected.

I could have opened an issue beforehand to discuss whether or not this was useful to submit as a PR or not, but I was going to do it for myself anyway, so I figured I might as well submit a PR! If this is not useful or something is missing, either just decline the PR or let me know, I'd be happy to find a solution that works for everyone :smile: 